### PR TITLE
Migrate NonBlockingCallback to BalEnv

### DIFF
--- a/runtime-native/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/Sleep.java
+++ b/runtime-native/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/Sleep.java
@@ -17,8 +17,9 @@
  */
 package org.ballerinalang.stdlib.runtime.nativeimpl;
 
-import org.ballerinalang.jvm.scheduling.Scheduler;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
+
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.BalFuture;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -35,30 +36,8 @@ public class Sleep {
 
     private static ScheduledExecutorService executor = Executors.newScheduledThreadPool(CORE_THREAD_POOL_SIZE);
 
-    public static void sleep(long delayMillis) {
-        schedule(new NonBlockingCallback(Scheduler.getStrand())::notifySuccess, delayMillis);
-    }
-
-    /**
-     * This can be used to register a callback to be triggered after the given delay. The callback
-     * must not block the execution in any way, and should return as soon as possible. The duration to
-     * execute the callback will affect other awaiting callbacks.
-     * @param callback the callback to be invoked after the given delay
-     * @param delayMillis the trigger delay in milliseconds
-     */
-    public static void schedule(TimerCallback callback, long delayMillis) {
-        executor.schedule(callback::execute, delayMillis, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Represents the timer callback.
-     */
-    public interface TimerCallback {
-
-        /**
-         * This is executed when the timer is triggered.
-         */
-        void execute();
-
+    public static void sleep(BalEnv env, long delayMillis) {
+        BalFuture balFuture = env.markAsync();
+        executor.schedule(() -> balFuture.complete(null), delayMillis, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
## Purpose
Remove deprecated API

## Goals
Replace deprecated API NonBlockingCallback with BalEnv param for interop

## Related PRs
API deprecated in - ballerina-platform/ballerina-lang#25787
Duplicate change prior to stdlib move - ballerina-platform/ballerina-lang#25854
